### PR TITLE
Fix multipleDeposits Bug

### DIFF
--- a/contracts/DaoDepositManager.sol
+++ b/contracts/DaoDepositManager.sol
@@ -154,22 +154,7 @@ contract DaoDepositManager {
             _tokens.length == _amounts.length,
             "D2D-DEPOSIT-ARRAY-LENGTH-MISMATCH"
         );
-
-        bool ethDepositDone = false;
         for (uint256 i; i < _tokens.length; ++i) {
-            // Due to the nature of msg.value in ETH-based transfers
-            // and the input parameter _amount that we use, the
-            // safest way to prevent any problems here is only
-            // to allow ONE of the deposits in here to be in ETH
-            // (there is no need to have multiple of them anyways)
-            if (_tokens[i] == address(0)) {
-                // If this would be true, this wouldn't be the first
-                // time we are here
-                require(!ethDepositDone, "");
-                // Setting it to true = first time we are here
-                ethDepositDone = true;
-            }
-
             deposit(_module, _dealId, _tokens[i], _amounts[i]);
         }
     }


### PR DESCRIPTION
### What is this?
Prior to this, there was a bug. If you used the `multipleDeposits()` function, it wouldn't work if you included one ETH-based deposit and one token-based deposit. Due to the checks in the `deposit()`, it was blocking the ETH-based deposits because of the `_amount` being greater than zero and it blocked the token-based deposits because of the `msg.value` being greater than zero.

### What did I do?
I fixed it! We will now just use the `_amount` variable for ALL deposits, no matter if ETH or token. If it's an ETH-based deposit, the `msg.value` has to match the `_amount`.

### Side-Note
It's **not** possible to do more than **one** ETH-based deposit for each `multipleDeposits()` call at a time. This is due to the `msg.value` staying unchanged and the `verifyBalance()` call reverting after the second iteration. This doesn't really matter as I don't see a good use-case to do two or more ETH-based deposits in one `multipleDeposits()` call at all. Just noting it.