### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# The members of the Deals-Contracts-CODEOWNERS Github team will be the code owners of the
+
+# Deals-contracts repo
+
+- @PrimeDAO/deals-contracts-codeowners


### PR DESCRIPTION
Added a file that defines the team that is able to merge a PR on
Github. This is done to protect the merging of code into the main
and development branch