### PR TITLE
chore: add CODEOWNERS file to the main branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# The members of the Deals-Contracts-CODEOWNERS Github team will be the code owners of the
+
+# Deals-contracts repo
+
+* @PrimeDAO/deals-contracts-codeowners


### PR DESCRIPTION
By adding the CODEOWNERS file, we enforce who has to review the PR
and by doing so, who can merge to the main branch